### PR TITLE
[6916] Localization support & i18n fixes

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -443,12 +443,14 @@ TIME_ZONE = 'UTC'
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True
+USE_THOUSAND_SEPARATOR = True
 
 LOCALE_PATHS = (
     os.path.join(BASE_DIR, 'locale'),
     os.path.join(BASE_DIR, 'networkapi/wagtailpages/templates/about/locale'),
     os.path.join(BASE_DIR, 'networkapi/wagtailpages/templates/buyersguide/locale'),
     os.path.join(BASE_DIR, 'networkapi/wagtailpages/templates/wagtailpages/pages/locale'),
+    os.path.join(BASE_DIR, 'networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/locale'),
 )
 
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_close_button.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_close_button.html
@@ -1,5 +1,5 @@
 {% load static i18n %}
 <button class="justify-content-center align-items-center mx-auto btn d-none p-0" aria-label="{% trans "Close Tab" %}" data-accordion-close-button>
-  <span class="heading-5">Close</span>
+  <span class="heading-5">{% trans "Close" %}</span>
   <img class="ml-2 flex-shrink-0" src="{% static "_images/youtube-regrets/minus-circle.svg" %}" alt="">
 </button>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_heading_button.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_heading_button.html
@@ -6,7 +6,7 @@
         <div class="row">
           <div class="col-12 col-md-1 yt-regrets-accordion__number">{{ number }}</div>
           <div class="col-12 col-md-11">
-            <h2 class="h2-heading">{% trans heading_text %}</h2>
+            <h2 class="h2-heading">{{ heading_text }}</h2>
           </div>
         </div>
       </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_1.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_1.html
@@ -1,18 +1,24 @@
 {% load i18n %}
 
   <p class="mb-5 pb-3">{% trans "YouTube Regrets are primarily a result of the recommendation algorithm, meaning videos that YouTube chooses to amplify, rather than videos that people sought out." %}</p>
-  <p class="heading-2 mb-5">{% trans "71% of all regret reports came from videos recommended to our users and recommended videos were 1.4 times more likely to be regretted than videos searched for. " %}</p>
+  <p class="heading-2 mb-5">{% trans "71% of all regret reports came from videos recommended to our users and recommended videos were 1.4 times more likely to be regretted than videos searched for." %}</p>
   <div class="col-12 col-lg-8 mx-auto">
     <canvas class="" width="410" height="410" id="recommendations-pie-chart"></canvas>
   </div>
-  {% blocktrans %}
-    <p class="mt-5 mb-lg-5 pb-lg-5">The regrets our volunteers flagged had tons of views, but it's impossible to tell how many of those views came from YouTube’s recommendation algorithm, because <span class="fw-bold">YouTube won’t release this information</span>.</p>
-  {% endblocktrans %}
+
+    <p class="mt-5 mb-lg-5 pb-lg-5">
+      {% blocktrans trimmed %}
+      The regrets our volunteers flagged had tons of views, but it’s impossible to tell how many of those views came from YouTube’s recommendation algorithm, because <span class="fw-bold">YouTube won’t release this information</span>.
+      {% endblocktrans %}
+    </p>
 
   <div class="row flex-column-reverse flex-lg-row">
     <div class="col-12 col-lg-5">
-      {% include "./standout-stat.html" with heading="Reported Videos" number="5794" label="views per day" classes="mb-5" id="reported-views-per-day-count-up" %}
-      {% include "./standout-stat.html" with heading="Other Videos" number="3312" label="views per day" id="other-views-per-day-count-up" %}
+      {% trans "Reported Videos" as reported_videos %}
+      {% trans "Other Videos" as other_videos %}
+      {% trans "views per day" as view_per_day %}
+      {% include "./standout-stat.html" with heading=reported_videos number=5794 label=view_per_day classes="mb-5" id="reported-views-per-day-count-up" %}
+      {% include "./standout-stat.html" with heading=other_videos number=3312 label=view_per_day id="other-views-per-day-count-up" %}
     </div>
     <div class="col-12 col-lg-6 offset-lg-1 mt-3 mt-lg-3">
       <h2 class="heading-2 mb-4">{% trans "What we do know is that reported videos seemed to accumulate views faster than those that were not." %}</h2>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_2.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_2.html
@@ -1,17 +1,22 @@
 {% load i18n %}
-<p class="mb-5 pb-3">{% trans "Our data shows that YouTube's algorithm recommended several videos that were later removed from the platform for violating YouTube's own Community Guidelines." %}</p>
+<p class="mb-5 pb-3">{% trans "Our data shows that YouTube’s algorithm recommended several videos that were later removed from the platform for violating YouTube’s own Community Guidelines." %}</p>
 
 <p class="heading-2 mb-5">{% trans "In 40% of cases where recommended YouTube Regrets were taken down from YouTube, YouTube did not provide data about the reason why these videos were removed." %}</p>
 
-{% blocktrans %}
-  <p class="mt-5 mb-lg-5 pb-lg-5">What we do know is at the time they were reported they had racked up a collective 160 million views, an average of 760 thousand views per video, accrued over 160 average days that the videos had been up at the time they were reported. It is impossible to tell how many of these views were a result of recommendations, because <span class="fw-bold">YouTube won’t release this information</span>.</p>
-{% endblocktrans %}
+  <p class="mt-5 mb-lg-5 pb-lg-5">
+    {% blocktrans trimmed %}
+    What we do know is at the time they were reported they had racked up a collective 160 million views, an average of 760 thousand views per video, accrued over 160 average days that the videos had been up at the time they were reported. It is impossible to tell how many of these views were a result of recommendations, because <span class="fw-bold">YouTube won’t release this information</span>.
+    {% endblocktrans %}
+  </p>
+
 
 <div class="row flex-xl-row">
   <div class="col-12 col-xl-7">
-    {% include "./standout-stat.html" with number="160000000" label="views over ~160 days" classes="mb-5" id="views-160days-count-up" smaller=True %}
+    {% trans "views over ~160 days" as views_over_160_days %}
+    {% include "./standout-stat.html" with number=160000000 label=views_over_160_days classes="mb-5" id="views-160days-count-up" smaller=True %}
   </div>
   <div class="col-12 col-xl-5 mt-3 mt-xl-0 ml-xl-10">
-    {% include "./standout-stat.html" with number="760" label="views per video" classes="mb-5" id="views-per-video-count-up" %}
+    {% trans "views per video" as views_per_video %}
+    {% include "./standout-stat.html" with number=760 label=views_per_video classes="mb-5" id="views-per-video-count-up" %}
   </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/carousel.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/carousel.html
@@ -21,14 +21,17 @@
         </div>
         <div class="carousel__item-content">
           <img class="carousel__speech-bubble-desktop mb-4" src="{% static "_images/youtube-regrets/speech-bubble-sad.svg" %}" alt="">
-          {% blocktrans %}
           <p class="carousel__item-text">
-            &ldquo;In coming out to myself and close friends as transgender, <span>my biggest regret was turning to YouTube to hear the stories of other trans and queer people.</span> Simply typing in the word 'transgender' brought up countless videos that were essentially describing my struggle as a mental illness and as something that shouldn't exist. YouTube reminded me why I hid in the closet for so many years.
+            {% blocktrans trimmed %}
+            “In coming out to myself and close friends as transgender, <span>my biggest regret was turning to YouTube to hear the stories of other trans and queer people.</span> Simply typing in the word 'transgender' brought up countless videos that were essentially describing my struggle as a mental illness and as something that shouldn't exist. YouTube reminded me why I hid in the closet for so many years.
+            {% endblocktrans %}
           </p>
           <p class="carousel__item-text">
-            Every now and then YouTube will continue to recommend me a video that tells me that my gender identity is wrong — and it reminds me of how much hate is squarely directed at me and people like me. I'm somewhat older, I've been dealing with these issues internally for a long time and I have therapy to work out these issues, but I can't imagine what it's like for those without access to help. <span>YouTube is a part of my pain in coming out</span> and is a reminder of how terrible this world can be to those who are different. I have to be proud in spite of places like YouTube.&rdquo;
+            {% blocktrans trimmed %}
+            Every now and then YouTube will continue to recommend me a video that tells me that my gender identity is wrong — and it reminds me of how much hate is squarely directed at me and people like me. I'm somewhat older, I've been dealing with these issues internally for a long time and I have therapy to work out these issues, but I can't imagine what it's like for those without access to help. <span>YouTube is a part of my pain in coming out</span> and is a reminder of how terrible this world can be to those who are different. I have to be proud in spite of places like YouTube.”
+            {% endblocktrans %}
           </p>
-          {% endblocktrans %}
+
         </div>
       </li>
       <li class="carousel__item glide__slide">
@@ -38,8 +41,8 @@
         <div class="carousel__item-content">
           <img class="carousel__speech-bubble-desktop mb-4" src="{% static "_images/youtube-regrets/speech-bubble-sad.svg" %}" alt="">
           <p class="carousel__item-text">
-            {% blocktrans %}
-            &ldquo;When my son was preschool age, he liked to watch 'Thomas the Tank Engine' videos on YouTube. One time when I checked on him, he was watching a video compilation that <span>contained graphic depictions of train wrecks.</span>&rdquo;
+            {% blocktrans trimmed %}
+            “When my son was preschool age, he liked to watch 'Thomas the Tank Engine' videos on YouTube. One time when I checked on him, he was watching a video compilation that <span>contained graphic depictions of train wrecks.</span>”
             {% endblocktrans %}
           </p>
         </div>
@@ -50,14 +53,17 @@
         </div>
         <div class="carousel__item-content">
           <img class="carousel__speech-bubble-desktop mb-4" src="{% static "_images/youtube-regrets/speech-bubble-sad.svg" %}" alt="">
-          {% blocktrans %}
           <p class="carousel__item-text">
-            &ldquo;My eight-year-old granddaughter was using our tablet to watch children's videos; unknowingly as grandparents we thought she was safe. The next day we watched as our granddaughter sat at the dinner table <span>speaking candidly to her parents about her fear of cancer.</span>
+            {% blocktrans trimmed %}
+            “My eight-year-old granddaughter was using our tablet to watch children's videos; unknowingly as grandparents we thought she was safe. The next day we watched as our granddaughter sat at the dinner table <span>speaking candidly to her parents about her fear of cancer.</span>
+            {% endblocktrans %}
           </p>
           <p class="carousel__item-text">
-            As it turned out, in the middle of watching how children with medical challenges can do great, inspirational things, the video turned dark and <span>began showing horrifying, raw footage of rotting skins and disfiguration.</span> Now we are working with her to understand cancer and to not fear eating food or drinking water.&rdquo;
+            {% blocktrans trimmed %}
+            As it turned out, in the middle of watching how children with medical challenges can do great, inspirational things, the video turned dark and <span>began showing horrifying, raw footage of rotting skins and disfiguration.</span> Now we are working with her to understand cancer and to not fear eating food or drinking water.”
+            {% endblocktrans %}
           </p>
-          {% endblocktrans %}
+
         </div>
       </li>
       <li class="carousel__item glide__slide">
@@ -67,8 +73,8 @@
         <div class="carousel__item-content">
           <img class="carousel__speech-bubble-desktop mb-4" src="{% static "_images/youtube-regrets/speech-bubble-sad.svg" %}" alt="">
           <p class="carousel__item-text">
-            {% blocktrans %}
-            &ldquo;My 10-year-old sweet daughter innocently searched for 'tap dance videos' and now is in this spiral of recommended videos of <span>extreme 'dance' and contortionist videos</span> that give her horrible unsafe body-harming and body-image-damaging advice... She is now restricting her eating and drinking. I don’t know <span>how I can undo the damage that’s been done</span> to her impressionable mind.&rdquo;
+            {% blocktrans trimmed %}
+            “My 10-year-old sweet daughter innocently searched for 'tap dance videos' and now is in this spiral of recommended videos of <span>extreme 'dance' and contortionist videos</span> that give her horrible unsafe body-harming and body-image-damaging advice... She is now restricting her eating and drinking. I don’t know <span>how I can undo the damage that’s been done</span> to her impressionable mind.”
             {% endblocktrans %}
           </p>
         </div>
@@ -79,14 +85,17 @@
         </div>
         <div class="carousel__item-content">
           <img class="carousel__speech-bubble-desktop mb-4" src="{% static "_images/youtube-regrets/speech-bubble-sad.svg" %}" alt="">
-          {% blocktrans %}
           <p class="carousel__item-text">
-            &ldquo;My ex-wife, who has mental health problems, started watching conspiracy videos three years ago and believed every single one. YouTube just kept feeding her paranoia, fear and anxiety one video after another. I kept begging her to stop, but she didn't — she couldn't. <span>At one point she believed a helicopter near the house was the government coming to take her and my daughter away</span> (they were really checking the power lines) and called in a blind panic. Now she's convinced the world is going to end any day now and is an extreme religious fundamentalist.
+            {% blocktrans trimmed %}
+            “My ex-wife, who has mental health problems, started watching conspiracy videos three years ago and believed every single one. YouTube just kept feeding her paranoia, fear and anxiety one video after another. I kept begging her to stop, but she didn't — she couldn't. <span>At one point she believed a helicopter near the house was the government coming to take her and my daughter away</span> (they were really checking the power lines) and called in a blind panic. Now she's convinced the world is going to end any day now and is an extreme religious fundamentalist.
+            {% endblocktrans %}
           </p>
           <p class="carousel__item-text">
-            She refuses to even consider professional help because she no longer trusts anyone — especially doctors, the police and any government-run organisation. <span>And YouTube just keeps feeding her more and more of the fear videos.</span> My marriage is now over. Her extraordinary fear has totally consumed her and our life together.&rdquo;
+            {% blocktrans trimmed %}
+            She refuses to even consider professional help because she no longer trusts anyone — especially doctors, the police and any government-run organisation. <span>And YouTube just keeps feeding her more and more of the fear videos.</span> My marriage is now over. Her extraordinary fear has totally consumed her and our life together.”
+            {% endblocktrans %}
           </p>
-          {% endblocktrans %}
+
         </div>
       </li>
     </ul>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/categories.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/categories.html
@@ -6,9 +6,11 @@
       <div class="row justify-content-center">
         <div class="col-12 col-md-8 mb-5 pb-3">
           <h2 class="heading-1">{% trans "The most common reported category was misinformation, especially covid-19 related." %}</h2>
-          {% blocktrans %}
-            <p>While our research considers the broad spectrum of YouTube Regrets, it is important to note that some videos are worse than others. YouTube has Community Guidelines that set the rules for what is allowed on YouTube and what isn’t. Together with a team of research assistants from the University of Exeter, we evaluated the videos reported to us against these Community Guidelines and determined which ones should either not be on YouTube or not be recommended by YouTube. Of those videos, the most common category applicable was misinformation (especially COVID-19 related). The other largest categories were violent or graphic content, hate speech, and spam/scams. Other notable categories include child safety, harassment & cyberbullying, and animal abuse.</p>
+          <p>
+          {% blocktrans trimmed %}
+            While our research considers the broad spectrum of YouTube Regrets, it is important to note that some videos are worse than others. YouTube has Community Guidelines that set the rules for what is allowed on YouTube and what isn’t. Together with a team of research assistants from the University of Exeter, we evaluated the videos reported to us against these Community Guidelines and determined which ones should either not be on YouTube or not be recommended by YouTube. Of those videos, the most common category applicable was misinformation (especially COVID-19 related). The other largest categories were violent or graphic content, hate speech, and spam/scams. Other notable categories include child safety, harassment & cyberbullying, and animal abuse.
           {% endblocktrans %}
+          </p>
         </div>
         <div class="col-12 col-md-8 categories__chart-heading">
           <h2 class="heading-5 mb-2">{% trans "Types of Regretted Content" %}</h2>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/hero.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/hero.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static i18n %}
 <div class="container dark-theme mb-3">
   <div class="hero">
     <div class="row">
@@ -6,10 +6,14 @@
         <img class="hero__image hero__image--mobile" src="{% static "_images/youtube-regrets/regrets-reporter/report-findings-hero-mobile.png" %}" alt="">
         <img class="hero__image hero__image--desktop" src="{% static "_images/youtube-regrets/regrets-reporter/report-findings-hero-desktop.png" %}" alt="">
         <div class="hero__guts">
-          <h1 class="mb-3 hero-heading">YouTube Regrets</h1>
-          <p class="body-large">Mozilla and 37,00 YouTube users conducted a study to better understand harmful YouTube recommendations. <span class="fst-italic">This is what we learned</span>.</p>
+          <h1 class="mb-3 hero-heading">{% trans "YouTube Regrets" %}</h1>
+          <p class="body-large">
+            {% blocktrans trimmed %}
+            Mozilla and 37,380 YouTube users conducted a study to better understand harmful YouTube recommendations. <span class="fst-italic">This is what we learned</span>.
+            {% endblocktrans %}
+          </p>
           {# TODO - add in PDF URL #}
-          <a href="#" class="btn btn-download" download>Download Full Report</a>
+          <a href="#" class="btn btn-download" download>{% trans "Download Full Report" %}</a>
         </div>
       </div>
     </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/intro.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/intro.html
@@ -3,7 +3,7 @@
   <div class="row justify-content-center">
     <div class="col-12 col-md-8">
       <p>
-        {% blocktrans with stories_link='class="fw-bold" href=""' trimmed %}
+        {% blocktrans with stories_link='class="fw-bold" href="#TODO"' trimmed %}
         In 2019, Mozilla collected <a {{stories_link}}>countless stories</a> from people whose lives were impacted by YouTube’s recommendation algorithm. People had been exposed to misinformation, developed unhealthy body images, and become trapped in bizarre rabbit holes. The more stories we read, the more we realized how central YouTube has become to the lives of so many people — and just how much YouTube recommendations can impact their wellbeing.
         {% endblocktrans %}
       </p>
@@ -13,7 +13,7 @@
         {% endblocktrans %}
       </p>
       <p>
-        {% blocktrans with reporter_link='class="fw-bold" href="#"' trimmed %}
+        {% blocktrans with reporter_link='class="fw-bold" href="#TODO"' trimmed %}
         Faced with this continuous refusal, Mozilla built a browser extension, <a {{reporter_link}}>RegretsReporter</a>, that allows people to donate data about the YouTube videos they regret watching on YouTube. Through one of the biggest crowdsourced investigations into YouTube, we’ve uncovered new information that warrants urgent attention and action from lawmakers and the public.
         {% endblocktrans %}
       </p>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/intro.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/intro.html
@@ -1,10 +1,27 @@
+{% load i18n %}
 <div class="container dark-theme mb-3">
   <div class="row justify-content-center">
     <div class="col-12 col-md-8">
-      <p>In 2019, Mozilla collected <a class="fw-bold" href="">countless stories</a> from people whose lives were impacted by YouTube’s recommendation algorithm. People had been exposed to misinformation, developed unhealthy body images, and become trapped in bizarre rabbit holes. The more stories we read, the more we realized how central YouTube has become to the lives of so many people — and just how much YouTube recommendations can impact their wellbeing.</p>
-      <p class="mb-5 pb-4">Yet when confronted about its recommendation algorithm, <span class="fw-bold">YouTube’s routine response is to deny and deflect</span>.</p>
-      <p>Faced with this continuous refusal, Mozilla built a browser extension, <a class="fw-bold" href="#">RegretsReporter</a>, that allows people to donate data about the YouTube videos they regret watching on YouTube. Through one of the biggest crowdsourced investigations into YouTube, we’ve uncovered new information that warrants urgent attention and action from lawmakers and the public.</p>
-      <p class="fw-bold">We now know that YouTube is recommending videos that violate their very own policies and harm users around the world — and that needs to stop.</p>
+      <p>
+        {% blocktrans with stories_link='class="fw-bold" href=""' trimmed %}
+        In 2019, Mozilla collected <a {{stories_link}}>countless stories</a> from people whose lives were impacted by YouTube’s recommendation algorithm. People had been exposed to misinformation, developed unhealthy body images, and become trapped in bizarre rabbit holes. The more stories we read, the more we realized how central YouTube has become to the lives of so many people — and just how much YouTube recommendations can impact their wellbeing.
+        {% endblocktrans %}
+      </p>
+      <p class="mb-5 pb-4">
+        {% blocktrans trimmed %}
+        Yet when confronted about its recommendation algorithm, <span class="fw-bold">YouTube’s routine response is to deny and deflect</span>.
+        {% endblocktrans %}
+      </p>
+      <p>
+        {% blocktrans with reporter_link='class="fw-bold" href="#"' trimmed %}
+        Faced with this continuous refusal, Mozilla built a browser extension, <a {{reporter_link}}>RegretsReporter</a>, that allows people to donate data about the YouTube videos they regret watching on YouTube. Through one of the biggest crowdsourced investigations into YouTube, we’ve uncovered new information that warrants urgent attention and action from lawmakers and the public.
+        {% endblocktrans %}
+      </p>
+      <p class="fw-bold">
+        {% blocktrans trimmed %}
+        We now know that YouTube is recommending videos that violate their very own policies and harm users around the world — and that needs to stop.
+        {% endblocktrans %}
+      </p>
     </div>
   </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/our-research.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/our-research.html
@@ -1,4 +1,4 @@
-{% load static i18n %}
+{% load static i18n l10n %}
 
 <div class="our-research pt-5">
   <img class="d-none d-md-block mx-auto mb-5 pb-5" src="{% static "_images/youtube-regrets/regrets-reporter/our-research-desktop.png" %}" alt="">
@@ -6,9 +6,9 @@
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-12 col-md-8 text-center">
-        <h2 class="heading-1 ">{% trans "Our research is powered by real Youtube users." %}</h2>
+        <h2 class="heading-1 ">{% trans "Our research is powered by real YouTube users." %}</h2>
         <p class="mb-5">
-          {% blocktrans %}
+          {% blocktrans trimmed %}
             Specifically: <span class="fw-bold">37,380 volunteers</span> across <span class="fw-bold">190 countries</span> installed Mozilla’s RegretsReporter browser extensions for Firefox and Chrome.
           {% endblocktrans %}
         </p>
@@ -16,27 +16,35 @@
       </div>
     </div>
 
+    {% with reports_count=5234 volunteers_count=1662 countries_count=91 %}
     <div class="row align-items-center mb-5">
       <div class="col-md-4 col-xs-12 stat">
-        <p class="stat__number" id="reports-count-up">5,234</p>
+        <p class="stat__number" id="reports-count-up">{{ reports_count|localize }}</p>
         <p class="stat__label">{% trans "Reports" %}</p>
       </div>
       <div class="col-md-4 col-xs-12 stat">
-        <p class="stat__number" id="volunteers-count-up">1,662</p>
+        <p class="stat__number" id="volunteers-count-up">{{ volunteers_count|localize }}</p>
         <p class="stat__label">{% trans "Volunteers" %}</p>
       </div>
       <div class="col-md-4 col-xs-12 stat">
-        <p class="stat__number" id="countries-count-up">91</p>
+        <p class="stat__number" id="countries-count-up">{{ countries_count|localize }}</p>
         <p class="stat__label">{% trans "Countries" %}</p>
       </div>
     </div>
+    {% endwith %}
 
     <div class="row justify-content-center mb-5">
       <div class="col-12 col-md-8 text-center">
-        {% blocktrans %}
-          <p>Reports were submitted between <span class="fw-bold">July 2020 - May 2021</span>. Volunteers who downloaded the extension but did <span class="fw-bold">not</span> file a report were an important part of our study. Their passive data — for example, how often they use YouTube — was essential to our understanding of how frequent regrettable experiences are on YouTube and how this varies between countries.</p>
-          <p class="mb-5 pb-5">After delving into the data with a team of research assistants from the University of Exeter, Mozilla came away with three major criticisms of YouTube recommendations: from a problematic algorithm to poor corporate oversight to geographic discrimination. —And our <a href="#">past research</a> shows that these problems can inflict lasting harm on people.</p>
-        {% endblocktrans %}
+          <p>
+            {% blocktrans trimmed %}
+            Reports were submitted between <span class="fw-bold">July 2020 - May 2021</span>. Volunteers who downloaded the extension but did <span class="fw-bold">not</span> file a report were an important part of our study. Their passive data — for example, how often they use YouTube — was essential to our understanding of how frequent regrettable experiences are on YouTube and how this varies between countries.
+            {% endblocktrans %}
+          </p>
+          <p class="mb-5 pb-5">
+            {% blocktrans with research_link="#" trimmed %}
+            After delving into the data with a team of research assistants from the University of Exeter, Mozilla came away with three major criticisms of YouTube recommendations: from a problematic algorithm to poor corporate oversight to geographic discrimination. —And our <a href="{{research_link}}">past research</a> shows that these problems can inflict lasting harm on people.
+            {% endblocktrans %}
+          </p>
 
         <h2 class="mb-1">{% trans "Here’s what we found" %}</h2>
         <p class="our-research__teaser mb-1 text-uppercase fst-italic">{% trans "(Click to read more)" %}</p>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/our-research.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/our-research.html
@@ -41,7 +41,7 @@
             {% endblocktrans %}
           </p>
           <p class="mb-5 pb-5">
-            {% blocktrans with research_link="#" trimmed %}
+            {% blocktrans with research_link="#TODO" trimmed %}
             After delving into the data with a team of research assistants from the University of Exeter, Mozilla came away with three major criticisms of YouTube recommendations: from a problematic algorithm to poor corporate oversight to geographic discrimination. —And our <a href="{{research_link}}">past research</a> shows that these problems can inflict lasting harm on people.
             {% endblocktrans %}
           </p>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/quote.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/quote.html
@@ -4,14 +4,13 @@
     <div class="col-12 col-md-8">
       <img class="mb-3" src="{% static "_images/youtube-regrets/regrets-reporter/quotation-mark.svg" %}" alt="">
       <blockquote class="quote">
-        {% blocktrans %}
-          <p class="quote__text fw-bold mb-3">
+        <p class="quote__text fw-bold mb-3">
+          {% blocktrans trimmed %}
             We set <span class="quote__highlight">a high bar</span> for what videos we display prominently in our recommendations on the YouTube homepage or through the 'Up next' panel.
-          </p>
-        {% endblocktrans %}
+          {% endblocktrans %}
+        </p>
         <cite class="quote__cite text-uppercase">{% trans "Youtube’s blog" %}</cite>
       </blockquote>
     </div>
   </div>
 </div>
-

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/standout-stat.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/standout-stat.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n l10n %}
 
 <div class="standout-stat stat {% if classes %}{{ classes }}{% endif %}">
   {% if heading %}
@@ -6,7 +6,7 @@
   {% endif %}
 
   <div class="standout-stat__wrap text-center p-4">
-    <p class="standout-stat__number mb-2 {% if smaller %}standout-stat__number--smaller{% endif %}" {% if id %}id="{{ id }}"{% endif %}>{{ number }}</p>
-    <p class="standout-stat__label mb-0">{% trans label %}</p>
+    <p class="standout-stat__number mb-2 {% if smaller %}standout-stat__number--smaller{% endif %}" {% if id %}id="{{ id }}"{% endif %}>{{ number|localize }}</p>
+    <p class="standout-stat__label mb-0">{{ label }}</p>
   </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/what-is.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/what-is.html
@@ -6,11 +6,21 @@
         <div class="what-is__guts col-12 offset-md-2 col-md-7">
             <h2 class="heading-1">{% trans "What is a YouTube Regret?" %}</h2>
             <div class="what-is__text">
-                {% blocktrans %}
-                    <p>The concept of a “YouTube Regret” was born out of a <a href="#">crowdsourced campaign</a> that Mozilla developed in 2019 to collect stories about YouTube’s recommendation algorithm leading people down bizarre and sometimes dangerous pathways. We have intentionally steered away from strictly defining what “counts” as a YouTube Regret to allow people to define the full spectrum of regrettable experiences that they have on YouTube.</p>
-                    <p>What a YouTube Regret looks like for one person may not be the same for another, and sometimes YouTube Regrets only emerge after months or weeks of being recommended videos—an experience which is better conveyed through <a href="#">stories</a> than video datasets.</p>
-                    <p>This approach intentionally centers the lived experiences of people to add to what is often a highly legalistic and theoretical discussion. It does not yield clear distinctions about what type of videos should or should not be on YouTube or algorithmically promoted by YouTube. </p>
-                {% endblocktrans %}
+                <p>
+                  {% blocktrans with campaign_link="#" trimmed %}
+                  The concept of a “YouTube Regret” was born out of a <a href="{{campaign_link}}">crowdsourced campaign</a> that Mozilla developed in 2019 to collect stories about YouTube’s recommendation algorithm leading people down bizarre and sometimes dangerous pathways. We have intentionally steered away from strictly defining what “counts” as a YouTube Regret to allow people to define the full spectrum of regrettable experiences that they have on YouTube.
+                  {% endblocktrans %}
+                </p>
+                <p>
+                  {% blocktrans with stories_link="#" trimmed %}
+                  What a YouTube Regret looks like for one person may not be the same for another, and sometimes YouTube Regrets only emerge after months or weeks of being recommended videos—an experience which is better conveyed through <a href="{{stories_link}}">stories</a> than video datasets.
+                  {% endblocktrans %}
+                </p>
+                <p>
+                  {% blocktrans trimmed %}
+                  This approach intentionally centers the lived experiences of people to add to what is often a highly legalistic and theoretical discussion. It does not yield clear distinctions about what type of videos should or should not be on YouTube or algorithmically promoted by YouTube.
+                  {% endblocktrans %}
+                </p>
             </div>
         </div>
     </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/what-is.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/what-is.html
@@ -7,12 +7,12 @@
             <h2 class="heading-1">{% trans "What is a YouTube Regret?" %}</h2>
             <div class="what-is__text">
                 <p>
-                  {% blocktrans with campaign_link="#" trimmed %}
+                  {% blocktrans with campaign_link="#TODO" trimmed %}
                   The concept of a “YouTube Regret” was born out of a <a href="{{campaign_link}}">crowdsourced campaign</a> that Mozilla developed in 2019 to collect stories about YouTube’s recommendation algorithm leading people down bizarre and sometimes dangerous pathways. We have intentionally steered away from strictly defining what “counts” as a YouTube Regret to allow people to define the full spectrum of regrettable experiences that they have on YouTube.
                   {% endblocktrans %}
                 </p>
                 <p>
-                  {% blocktrans with stories_link="#" trimmed %}
+                  {% blocktrans with stories_link="#TODO" trimmed %}
                   What a YouTube Regret looks like for one person may not be the same for another, and sometimes YouTube Regrets only emerge after months or weeks of being recommended videos—an experience which is better conveyed through <a href="{{stories_link}}">stories</a> than video datasets.
                   {% endblocktrans %}
                 </p>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/youtube_regrets_accordion.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/youtube_regrets_accordion.html
@@ -25,7 +25,8 @@
         </div>
       </div>
 
-      {% include "./fragments/accordion_heading_button.html" with number="01" heading_text="Most videos people regret watching come from recommendations." %}
+      {% trans "Most videos people regret watching come from recommendations." as heading_section_1 %}
+      {% include "./fragments/accordion_heading_button.html" with number="01" heading_text=heading_section_1 %}
       {% include "./fragments/accordion_close_button.html" %}
     </div>
   </div>
@@ -53,7 +54,8 @@
         </div>
       </div>
 
-      {% include "./fragments/accordion_heading_button.html" with number="02" heading_text="YouTube recommends videos that violate their own policies." %}
+      {% trans "YouTube recommends videos that violate their own policies." as heading_section_2 %}
+      {% include "./fragments/accordion_heading_button.html" with number="02" heading_text=heading_section_2 %}
       {% include "./fragments/accordion_close_button.html" %}
     </div>
   </div>
@@ -87,7 +89,8 @@
         </div>
       </div>
 
-      {% include "./fragments/accordion_heading_button.html" with number="03" heading_text="The non-English speaking world is hit the hardest." %}
+      {% trans "The non-English speaking world is hit the hardest." as heading_section_3 %}
+      {% include "./fragments/accordion_heading_button.html" with number="03" heading_text=heading_section_3 %}
       {% include "./fragments/accordion_close_button.html" %}
     </div>
   </div>
@@ -123,7 +126,8 @@
         </div>
       </div>
 
-      {% include "./fragments/accordion_heading_button.html" with number="04" heading_text="YouTube Regrets can alter people’s lives forever." %}
+      {% trans "YouTube Regrets can alter people’s lives forever." as heading_section_4 %}
+      {% include "./fragments/accordion_heading_button.html" with number="04" heading_text=heading_section_4 %}
       {% include "./fragments/accordion_close_button.html" %}
     </div>
   </div>

--- a/source/js/foundation/pages/youtube-regrets/categories-bar-chart.js
+++ b/source/js/foundation/pages/youtube-regrets/categories-bar-chart.js
@@ -4,22 +4,22 @@ export const initYouTubeRegretsCategoriesBarChart = () => {
   Chart.register(...registerables);
 
   const labels = [
-    'MISINFORMATION',
-    'VIOLENT OR GRAPHIC CONTENT',
-    'COVID-19 MISINFORMATION',
-    'HATE SPEECH',
-    'SPAM',
-    'NUDITY & SEXUAL CONTENT',
-    'CHILD SAFETY',
-    'HARASSMENT & CYBERBULLYING',
-    'HARMFUL OR DANGEROUS',
-    'OTHER',
-    'FIREARMS',
-    'IMPERSONATION',
-    'ANIMAL ABUSE',
-    'AGE-RESTRICTED CONTENT',
-    'VIOLENT CRIMINAL ORGS',
-    'FAKE ENGAGEMENT'
+    gettext('MISINFORMATION'),
+    gettext('VIOLENT OR GRAPHIC CONTENT'),
+    gettext('COVID-19 MISINFORMATION'),
+    gettext('HATE SPEECH'),
+    gettext('SPAM'),
+    gettext('NUDITY & SEXUAL CONTENT'),
+    gettext('CHILD SAFETY'),
+    gettext('HARASSMENT & CYBERBULLYING'),
+    gettext('HARMFUL OR DANGEROUS'),
+    gettext('OTHER'),
+    gettext('FIREARMS'),
+    gettext('IMPERSONATION'),
+    gettext('ANIMAL ABUSE'),
+    gettext('AGE-RESTRICTED CONTENT'),
+    gettext('VIOLENT CRIMINAL ORGS'),
+    gettext('FAKE ENGAGEMENT')
   ]
 
   const data = [
@@ -43,6 +43,7 @@ export const initYouTubeRegretsCategoriesBarChart = () => {
 
   const categoriesChart = document.getElementById('categories-bar-chart');
   const ctx = categoriesChart.getContext('2d');
+  const labelFormat = gettext("%s%");
 
   const chart = new Chart(ctx, {
     type: 'bar',
@@ -90,7 +91,7 @@ export const initYouTubeRegretsCategoriesBarChart = () => {
               family: "Nunito Sans",
             },
             callback: function(value) {
-              return `${value}%`;
+              return interpolate(labelFormat, [value]);
             },
           }
         },

--- a/source/js/foundation/pages/youtube-regrets/count-up.js
+++ b/source/js/foundation/pages/youtube-regrets/count-up.js
@@ -2,13 +2,15 @@ import { CountUp } from 'countup.js';
 
 export const initYoutubeRegretsResearchCountUp = () => {
   if ('IntersectionObserver' in window) {
-    const reportCountUp = new CountUp('reports-count-up', 5234);
-    const volunteersCountUp = new CountUp('volunteers-count-up', 1662);
+    const localeSeparator = get_format('THOUSAND_SEPARATOR');
+    const localizedSuffix = gettext('K');
+    const reportCountUp = new CountUp('reports-count-up', 5234, { separator: localeSeparator });
+    const volunteersCountUp = new CountUp('volunteers-count-up', 1662, { separator: localeSeparator });
     const countriesCountUp = new CountUp('countries-count-up', 91);
-    const reportedViewsPerDayCountUp = new CountUp('reported-views-per-day-count-up', 5794, { prefix: '~' })
-    const otherViewsPerDayCountUp = new CountUp('other-views-per-day-count-up', 3312, { prefix: '~' })
-    const views160DaysCountUp = new CountUp('views-160days-count-up', 160000000);
-    const viewsPerVideoCountUp = new CountUp('views-per-video-count-up', 170, { prefix: '~', suffix: 'K' });
+    const reportedViewsPerDayCountUp = new CountUp('reported-views-per-day-count-up', 5794, { prefix: '~', separator: localeSeparator })
+    const otherViewsPerDayCountUp = new CountUp('other-views-per-day-count-up', 3312, { prefix: '~', separator: localeSeparator })
+    const views160DaysCountUp = new CountUp('views-160days-count-up', 160000000, { separator: localeSeparator });
+    const viewsPerVideoCountUp = new CountUp('views-per-video-count-up', 170, { prefix: '~', suffix: localizedSuffix });
 
     let observer = new IntersectionObserver(
       (entries, observer) => {

--- a/source/js/foundation/pages/youtube-regrets/recommendations-pie-chart.js
+++ b/source/js/foundation/pages/youtube-regrets/recommendations-pie-chart.js
@@ -5,14 +5,15 @@ export const initYouTubeRegretsRecommendationsPieChart = () => {
 
   const categoriesChart = document.getElementById('recommendations-pie-chart');
   const ctx = categoriesChart.getContext('2d');
+  const labelFormat = gettext("%s%");
 
   const chart = new Chart(ctx, {
     type: 'doughnut',
     data: {
       labels: [
-        'Recommendation',
-        'Search',
-        'Other'
+        gettext('Recommendation'),
+        gettext('Search'),
+        gettext('Other')
       ],
       datasets: [{
         data: [71.1, 21.5, 7.47],
@@ -36,7 +37,7 @@ export const initYouTubeRegretsRecommendationsPieChart = () => {
         },
         tooltip: {
           callbacks: {
-            label: (context) => `${context.parsed}%`,
+            label: (context) => interpolate(labelFormat, [context.parsed]),
           },
         },
       },


### PR DESCRIPTION
- Format numbers according to the current locale
- Move URLs out of translations into variables
- Move HTML tags out of translations as much as possible
- Split large content into smaller strings
- Fix heading_text localization (can’t dynamically pass strings to translate tags)